### PR TITLE
Add MUI theme and layout enhancements

### DIFF
--- a/express_shipping_website/README.md
+++ b/express_shipping_website/README.md
@@ -34,3 +34,19 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Design System
+
+The app uses a custom Material UI theme defined in `components/theme.ts`. The palette is designed to convey professionalism and trust:
+
+| Role       | Hex      |
+|------------|---------|
+| Primary    | `#0B3D91` |
+| Secondary  | `#007C91` |
+| Background | `#F5F5F5` |
+| Text       | `#333333` |
+| Accent     | `#FF6F00` |
+
+Typography defaults to a sans‑serif stack (`Inter`, `Roboto`, `Arial`, `sans-serif`). Heading sizes are tuned for proposals: `h1` at `2.5rem`, `h2` at `2rem`, and body text at `1rem`.
+
+To adjust colors or fonts, edit `components/theme.ts` and restart the dev server.

--- a/express_shipping_website/components/ColorSchemePreview.tsx
+++ b/express_shipping_website/components/ColorSchemePreview.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import Paper from '@mui/material/Paper';
+import Typography from '@mui/material/Typography';
+import Box from '@mui/material/Box';
+import { useTheme } from '@mui/material/styles';
+
+export default function ColorSchemePreview() {
+  const theme = useTheme();
+  const colors = [
+    { name: 'Primary', hex: theme.palette.primary.main },
+    { name: 'Secondary', hex: theme.palette.secondary.main },
+    { name: 'Background', hex: theme.palette.background.default },
+    { name: 'Text', hex: theme.palette.text.primary },
+    { name: 'Accent', hex: (theme.palette as any).accent?.main || '#FF6F00' },
+  ];
+
+  return (
+    <Box display="flex" gap={2} mt={2} justifyContent="center">
+      {colors.map(({ name, hex }) => (
+        <Paper
+          key={name}
+          sx={{
+            p: 2,
+            textAlign: 'center',
+            backgroundColor: hex,
+            color: theme.palette.getContrastText(hex),
+          }}
+        >
+          <Typography variant="body2">{name}</Typography>
+          <Typography variant="caption">{hex}</Typography>
+        </Paper>
+      ))}
+    </Box>
+  );
+}

--- a/express_shipping_website/components/Layout.tsx
+++ b/express_shipping_website/components/Layout.tsx
@@ -4,13 +4,14 @@ import AppBar from '@mui/material/AppBar';
 import Toolbar from '@mui/material/Toolbar';
 import Button from '@mui/material/Button';
 import Container from '@mui/material/Container';
+import Paper from '@mui/material/Paper';
 
 interface LayoutProps { children: ReactNode; }
 
 export default function Layout({ children }: LayoutProps) {
   return (
     <>
-      <AppBar position="static">
+      <AppBar position="static" color="primary">
         <Toolbar>
           {['Home','Website Design','Business Resources','About'].map((label, i) => {
             const href = ['/', '/website-design', '/business-resources-design', '/about'][i];
@@ -22,8 +23,10 @@ export default function Layout({ children }: LayoutProps) {
           })}
         </Toolbar>
       </AppBar>
-      <Container maxWidth="md" sx={{ my: 4 }}>
-        {children}
+      <Container maxWidth="md" sx={{ mt: 4, mb: 4 }}>
+        <Paper elevation={1} sx={{ p: 4, backgroundColor: 'background.default' }}>
+          {children}
+        </Paper>
       </Container>
     </>
   );

--- a/express_shipping_website/components/theme.ts
+++ b/express_shipping_website/components/theme.ts
@@ -1,0 +1,29 @@
+import { createTheme } from '@mui/material/styles';
+
+// Augment the palette to include an accent color
+declare module '@mui/material/styles' {
+  interface Palette {
+    accent: Palette['primary'];
+  }
+  interface PaletteOptions {
+    accent?: PaletteOptions['primary'];
+  }
+}
+
+const theme = createTheme({
+  palette: {
+    primary: { main: '#0B3D91' },
+    secondary: { main: '#007C91' },
+    background: { default: '#F5F5F5' },
+    text: { primary: '#333333' },
+    accent: { main: '#FF6F00' },
+  },
+  typography: {
+    fontFamily: ['Inter', 'Roboto', 'Arial', 'sans-serif'].join(','),
+    h1: { fontSize: '2.5rem' },
+    h2: { fontSize: '2rem' },
+    body1: { fontSize: '1rem' },
+  },
+});
+
+export default theme;

--- a/express_shipping_website/pages/_app.tsx
+++ b/express_shipping_website/pages/_app.tsx
@@ -1,10 +1,7 @@
 import type { AppProps } from 'next/app';
-import { ThemeProvider, CssBaseline, createTheme } from '@mui/material';
+import { ThemeProvider, CssBaseline } from '@mui/material';
 import Layout from '../components/Layout';
-
-const theme = createTheme({
-  palette: { mode: 'light' },
-});
+import theme from '../components/theme';
 
 export default function MyApp({ Component, pageProps }: AppProps) {
   return (


### PR DESCRIPTION
## Summary
- implement a custom Material UI theme with professional palette and typography
- wire custom theme in `_app.tsx`
- enhance layout with themed AppBar and Paper container
- add a color scheme preview component
- document design system in README

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6854954e0518832e8bec6cbdb04ce1f6