### PR TITLE
Enable Learn More button and remove placeholder

### DIFF
--- a/express_shipping_website/home-page/components/Hero.tsx
+++ b/express_shipping_website/home-page/components/Hero.tsx
@@ -2,29 +2,8 @@ import * as React from 'react';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Container from '@mui/material/Container';
-import InputLabel from '@mui/material/InputLabel';
 import Stack from '@mui/material/Stack';
-import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
-import { styled } from '@mui/material/styles';
-
-const StyledBox = styled('div')(({ theme }) => ({
-  alignSelf: 'center',
-  width: '100%',
-  height: 400,
-  marginTop: theme.spacing(8),
-  borderRadius: (theme.vars || theme).shape.borderRadius,
-  outline: '6px solid',
-  outlineColor: 'hsla(220, 25%, 80%, 0.2)',
-  border: '1px solid',
-  borderColor: (theme.vars || theme).palette.grey[200],
-  boxShadow: '0 0 12px 8px hsla(220, 25%, 80%, 0.2)',
-  backgroundSize: 'cover',
-  [theme.breakpoints.up('sm')]: {
-    marginTop: theme.spacing(10),
-    height: 700,
-  },
-}));
 
 export default function Hero() {
   return (
@@ -82,13 +61,18 @@ export default function Hero() {
           </Typography>
 
           {/* Secondary CTA */}
-          <Button variant="outlined" color="primary" size="small" sx={{ mt: 1 }}>
+          <Button
+            component="a"
+            href="#features"
+            variant="outlined"
+            color="primary"
+            size="small"
+            sx={{ mt: 1 }}
+          >
             Learn More
           </Button>
         </Stack>
 
-        {/* Placeholder for your background/illustration */}
-        <StyledBox id="image" />
       </Container>
     </Box>
   );


### PR DESCRIPTION
## Summary
- improve Hero component
  - make **Learn More** button scroll down to the features section
  - remove unused illustration box
- keep existing features anchor in place

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6856007a65a8832eab1bf653370ab391