### PR TITLE
Add Excalidraw page

### DIFF
--- a/express_shipping_website/README.md
+++ b/express_shipping_website/README.md
@@ -18,6 +18,8 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
 
+You can try the integrated Excalidraw canvas at `/excalidraw`.
+
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
 ## Learn More

--- a/express_shipping_website/pages/excalidraw.tsx
+++ b/express_shipping_website/pages/excalidraw.tsx
@@ -1,0 +1,16 @@
+import dynamic from 'next/dynamic';
+import Box from '@mui/material/Box';
+import '@excalidraw/excalidraw/index.css';
+
+const Excalidraw = dynamic(
+  () => import('@excalidraw/excalidraw').then((mod) => mod.Excalidraw),
+  { ssr: false }
+);
+
+export default function ExcalidrawPage() {
+  return (
+    <Box sx={{ height: '80vh' }}>
+      <Excalidraw />
+    </Box>
+  );
+}


### PR DESCRIPTION
## Summary
- integrate Excalidraw on `/excalidraw`
- mention the new page in README

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68560c0d9f04832e8b429b8e9524b4cb