### PR TITLE
Switch to dark marketing theme

### DIFF
--- a/express_shipping_website/pages/_app.tsx
+++ b/express_shipping_website/pages/_app.tsx
@@ -1,16 +1,16 @@
 import * as React from 'react';
 import type { AppProps } from 'next/app';
-import { ThemeProvider, CssBaseline } from '@mui/material';
+import CssBaseline from '@mui/material/CssBaseline';
 import Layout from '../components/Layout';
-import theme from '../components/theme';
+import AppTheme from '../shared-theme/AppTheme';
 
 export default function MyApp({ Component, pageProps }: AppProps) {
   const getLayout =
     (Component as any).getLayout || ((page: React.ReactNode) => <Layout>{page}</Layout>);
   return (
-    <ThemeProvider theme={theme}>
-      <CssBaseline />
+    <AppTheme>
+      <CssBaseline enableColorScheme />
       {getLayout(<Component {...pageProps} />)}
-    </ThemeProvider>
+    </AppTheme>
   );
 }

--- a/express_shipping_website/pages/index.tsx
+++ b/express_shipping_website/pages/index.tsx
@@ -1,7 +1,5 @@
 import HomePage from '../home-page/HomePage';
 
 export default function Home() {
-  return (
-    <HomePage disableCustomTheme />
-  );
+  return <HomePage />;
 }

--- a/express_shipping_website/pages/marketing.tsx
+++ b/express_shipping_website/pages/marketing.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import HomePage from '../home-page/HomePage';
 
 export default function Marketing() {
-  return <HomePage disableCustomTheme />;
+  return <HomePage />;
 }
 
 Marketing.getLayout = (page: React.ReactNode) => page;

--- a/express_shipping_website/shared-theme/AppTheme.tsx
+++ b/express_shipping_website/shared-theme/AppTheme.tsx
@@ -28,6 +28,7 @@ export default function AppTheme(props: AppThemeProps) {
             colorSchemeSelector: 'data-mui-color-scheme',
             cssVarPrefix: 'template',
           },
+          defaultColorScheme: 'dark',
           colorSchemes, // Recently added in v6 for building light & dark mode app, see https://mui.com/material-ui/customization/palette/#color-schemes
           typography,
           shadows,


### PR DESCRIPTION
## Summary
- apply the shared dark theme with `defaultColorScheme: 'dark'`
- wrap the app with `AppTheme`
- remove `disableCustomTheme` so pages use the theme

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685721baa764832e9e281df14d121db4