### PR TITLE
Fix app bar positioning and rename component

### DIFF
--- a/express_shipping_website/components/AppBar.tsx
+++ b/express_shipping_website/components/AppBar.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { styled, alpha } from '@mui/material/styles';
 import Box from '@mui/material/Box';
-import AppBar from '@mui/material/AppBar';
+import MuiAppBar from '@mui/material/AppBar';
 import Toolbar from '@mui/material/Toolbar';
 import Button from '@mui/material/Button';
 import IconButton from '@mui/material/IconButton';
@@ -11,8 +11,8 @@ import MenuItem from '@mui/material/MenuItem';
 import Drawer from '@mui/material/Drawer';
 import MenuIcon from '@mui/icons-material/Menu';
 import CloseRoundedIcon from '@mui/icons-material/CloseRounded';
-import ColorModeIconDropdown from '../../shared-theme/ColorModeIconDropdown';
-import Logo from './Logo';
+import ColorModeIconDropdown from '../shared-theme/ColorModeIconDropdown';
+import Logo from '../home-page/components/Logo';
 
 const StyledToolbar = styled(Toolbar)(({ theme }) => ({
   display: 'flex',
@@ -30,7 +30,7 @@ const StyledToolbar = styled(Toolbar)(({ theme }) => ({
   padding: '8px 12px',
 }));
 
-export default function AppAppBar() {
+export default function AppBar() {
   const [open, setOpen] = React.useState(false);
 
   const toggleDrawer = (newOpen: boolean) => () => {
@@ -38,7 +38,7 @@ export default function AppAppBar() {
   };
 
   return (
-    <AppBar
+    <MuiAppBar
       position="fixed"
       enableColorOnDark
       sx={{
@@ -70,6 +70,6 @@ export default function AppAppBar() {
           
         </StyledToolbar>
       </Container>
-    </AppBar>
+    </MuiAppBar>
   );
 }

--- a/express_shipping_website/components/Layout.tsx
+++ b/express_shipping_website/components/Layout.tsx
@@ -1,18 +1,16 @@
 import React, { ReactNode } from 'react';
-import Link from 'next/link';
-import AppBar from '@mui/material/AppBar';
 import Toolbar from '@mui/material/Toolbar';
-import Button from '@mui/material/Button';
 import Container from '@mui/material/Container';
 import Paper from '@mui/material/Paper';
-import AppAppBar from '@/home-page/components/AppAppBar';
+import AppBar from '@/components/AppBar';
 
 interface LayoutProps { children: ReactNode; }
 
 export default function Layout({ children }: LayoutProps) {
   return (
     <>
-      <AppAppBar />
+      <AppBar />
+      <Toolbar variant="dense" />
       <Container maxWidth="md" sx={{ mt: 4, mb: 4 }}>
         <Paper elevation={1} sx={{ p: 4, backgroundColor: 'background.default' }}>
           {children}

--- a/express_shipping_website/home-page/HomePage.tsx
+++ b/express_shipping_website/home-page/HomePage.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import CssBaseline from '@mui/material/CssBaseline';
 import Divider from '@mui/material/Divider';
 import AppTheme from '../shared-theme/AppTheme';
-import AppAppBar from './components/AppAppBar';
 import Hero from './components/Hero';
 import LogoCollection from './components/LogoCollection';
 import Highlights from './components/Highlights';


### PR DESCRIPTION
## Summary
- move `AppAppBar` to the shared components folder and rename it `AppBar`
- adjust imports for the renamed component
- offset page content below the fixed app bar

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685ec8a6ff88832e97d35163dedb66d0