### PR TITLE
Add background drawing to pages

### DIFF
--- a/express_shipping_website/components/Layout.tsx
+++ b/express_shipping_website/components/Layout.tsx
@@ -6,12 +6,30 @@ import Button from '@mui/material/Button';
 import Container from '@mui/material/Container';
 import Paper from '@mui/material/Paper';
 import AppAppBar from '@/components/MenuBar';
+import Box from '@mui/material/Box';
 
 interface LayoutProps { children: ReactNode; }
 
 export default function Layout({ children }: LayoutProps) {
   return (
     <>
+      <Box
+        aria-hidden="true"
+        sx={(theme) => ({
+          position: 'fixed',
+          top: 0,
+          left: 0,
+          width: '100%',
+          height: '100%',
+          zIndex: -1,
+          pointerEvents: 'none',
+          backgroundImage: 'url("/express_drawing.svg")',
+          backgroundSize: 'cover',
+          backgroundPosition: 'center',
+          opacity: 0.1,
+          filter: theme.palette.mode === 'dark' ? 'invert(1)' : 'none',
+        })}
+      />
       <AppAppBar />
       <Container maxWidth="md" sx={{ mt: 4, mb: 4 }}>
         <Paper elevation={1} sx={{ mt:10, p: 4, backgroundColor: 'background.default' }}>


### PR DESCRIPTION
## Summary
- incorporate the new `express_drawing.svg` image as a fixed page background
- invert the image for dark mode and keep it subtle with low opacity

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685ed4e5f354832ead17dee12f4dafdc