### PR TITLE
Fix message-bus chart path in deploy script

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -24,9 +24,9 @@ kubectl rollout status statefulset/database-postgresql -n infra --timeout=120s
 
 # === 3. Deploy Kafka (Strimzi) ===
 echo "🚀 Deploying Kafka..."
-helm upgrade --install kafka ./infrastructure/helm/message_bus \
+helm upgrade --install kafka ./infrastructure/helm/message-bus \
   --namespace infra --create-namespace \
-  -f infrastructure/helm/message_bus/values.yaml
+  -f infrastructure/helm/message-bus/values.yaml
 
 echo "⏳ Waiting for Kafka to be ready..."
 # adjust label if your Strimzi chart names it differently


### PR DESCRIPTION
## Summary
- fix typo in deploy script to use `message-bus` helm chart directory

## Testing
- `npm test` *(fails: this.orders.findOneOrFail is not a function)*
- `npm run lint` *(fails: NotFoundException is defined but never used)*
- `npm run lint` in `express_shipping_website`

------
https://chatgpt.com/codex/tasks/task_e_686bb9d0be30832ea8f049191e07799f