### PR TITLE
Add Keycloak Helm chart

### DIFF
--- a/infrastructure/helm/auth/keycloak/Chart.yaml
+++ b/infrastructure/helm/auth/keycloak/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: keycloak
+version: 0.1.0
+description: Minimal Keycloak deployment
+appVersion: "23.0.0"
+type: application
+dependencies: []

--- a/infrastructure/helm/auth/keycloak/templates/_helpers.tpl
+++ b/infrastructure/helm/auth/keycloak/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{- define "keycloak.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "keycloak.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/infrastructure/helm/auth/keycloak/templates/deployment.yaml
+++ b/infrastructure/helm/auth/keycloak/templates/deployment.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "keycloak.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "keycloak.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "keycloak.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "keycloak.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: keycloak
+          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args: ["start-dev"]
+          ports:
+            - containerPort: 8080
+          volumeMounts:
+            - name: data
+              mountPath: /opt/keycloak/data
+          resources: {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ include "keycloak.fullname" . }}

--- a/infrastructure/helm/auth/keycloak/templates/pvc.yaml
+++ b/infrastructure/helm/auth/keycloak/templates/pvc.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "keycloak.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "keycloak.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}

--- a/infrastructure/helm/auth/keycloak/templates/service.yaml
+++ b/infrastructure/helm/auth/keycloak/templates/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "keycloak.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "keycloak.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: {{ include "keycloak.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/infrastructure/helm/auth/keycloak/values.yaml
+++ b/infrastructure/helm/auth/keycloak/values.yaml
@@ -1,0 +1,28 @@
+replicaCount: 1
+
+image:
+  repository: quay.io/keycloak/keycloak
+  tag: "23.0.7"
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+  port: 8080
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: keycloak.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+
+persistence:
+  enabled: true
+  accessMode: ReadWriteOnce
+  size: 1Gi
+
+resources: {}


### PR DESCRIPTION
## Summary
- add a minimal Keycloak Helm chart under `infrastructure/helm/auth`

## Testing
- `helm lint infrastructure/helm/auth/keycloak` *(fails: helm not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686d0d4aee20832e93fd8bb8e2af2582