### PR TITLE
Add Order Management Helm chart

### DIFF
--- a/infra/helm/microservices/order-management/Chart.yaml
+++ b/infra/helm/microservices/order-management/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: order-management
+description: Order Management microservice
+version: 0.1.0
+appVersion: "0.0.1"
+type: application
+dependencies: []

--- a/infra/helm/microservices/order-management/templates/NOTES.txt
+++ b/infra/helm/microservices/order-management/templates/NOTES.txt
@@ -1,0 +1,9 @@
+1. To access the Order Management service run:
+
+   kubectl --namespace {{ .Release.Namespace }} port-forward svc/{{ include "order-management.fullname" . }} 3000:3000
+
+2. Ensure the following secrets exist with appropriate values:
+   - Database password secret: {{ .Values.database.secretName }} (key: `password`)
+   - Keycloak client secret: {{ .Values.keycloak.secretName }} (key: `clientSecret`)
+
+Environment variables are configured automatically from chart values and secrets.

--- a/infra/helm/microservices/order-management/templates/_helpers.tpl
+++ b/infra/helm/microservices/order-management/templates/_helpers.tpl
@@ -1,0 +1,34 @@
+{{- define "order-management.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "order-management.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "order-management.labels" -}}
+helm.sh/chart: {{ include "order-management.chart" . }}
+{{ include "order-management.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "order-management.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "order-management.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "order-management.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/infra/helm/microservices/order-management/templates/configmap.yaml
+++ b/infra/helm/microservices/order-management/templates/configmap.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "order-management.fullname" . }}
+  labels:
+    {{- include "order-management.labels" . | nindent 4 }}
+data:
+  KAFKA_TOPIC: {{ .Values.kafka.topic | quote }}

--- a/infra/helm/microservices/order-management/templates/deployment.yaml
+++ b/infra/helm/microservices/order-management/templates/deployment.yaml
@@ -1,0 +1,57 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "order-management.fullname" . }}
+  labels:
+    {{- include "order-management.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "order-management.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "order-management.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 3000
+              protocol: TCP
+          env:
+            - name: DATABASE_URL
+              value: postgres://{{ .Values.database.user }}:$(DB_PASSWORD)@{{ .Values.database.host }}:{{ .Values.database.port }}/{{ .Values.database.name }}
+            - name: KAFKA_BOOTSTRAP_SERVERS
+              value: {{ .Values.kafka.bootstrapServers }}
+            - name: KAFKA_TOPIC
+              value: {{ .Values.kafka.topic }}
+            - name: KEYCLOAK_URL
+              value: {{ .Values.keycloak.url }}
+            - name: KEYCLOAK_REALM
+              value: {{ .Values.keycloak.realm }}
+            - name: KEYCLOAK_CLIENT_ID
+              value: {{ .Values.keycloak.clientId }}
+            - name: KEYCLOAK_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.keycloak.secretName }}
+                  key: clientSecret
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.database.secretName }}
+                  key: password
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}

--- a/infra/helm/microservices/order-management/templates/secret.yaml
+++ b/infra/helm/microservices/order-management/templates/secret.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.database.password }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.database.secretName }}
+  labels:
+    {{- include "order-management.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  password: {{ .Values.database.password | quote }}
+{{- end }}
+{{- if .Values.keycloak.clientSecret }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.keycloak.secretName }}
+  labels:
+    {{- include "order-management.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  clientSecret: {{ .Values.keycloak.clientSecret | quote }}
+{{- end }}

--- a/infra/helm/microservices/order-management/templates/service.yaml
+++ b/infra/helm/microservices/order-management/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "order-management.fullname" . }}
+  labels:
+    {{- include "order-management.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 3000
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "order-management.selectorLabels" . | nindent 4 }}

--- a/infra/helm/microservices/order-management/values.yaml
+++ b/infra/helm/microservices/order-management/values.yaml
@@ -1,0 +1,33 @@
+image:
+  repository: order-management
+  tag: "latest"
+  pullPolicy: IfNotPresent
+
+replicaCount: 1
+
+database:
+  host: postgres
+  port: 5432
+  name: orders
+  user: order_user
+  password: ""
+  secretName: order-management-db
+
+kafka:
+  bootstrapServers: kafka:9092
+  topic: orders
+
+keycloak:
+  url: http://keycloak
+  realm: shipping
+  clientId: order-management
+  clientSecret: ""
+  secretName: order-management-keycloak
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 200m
+    memory: 256Mi


### PR DESCRIPTION
## Summary
- add Helm chart for order-management microservice under `infra/helm`
- include deployment, service, secrets, configmap and helper templates

## Testing
- `npm ci` *(install deps)*
- `npm test` *(fails: this.orders.findOneOrFail is not a function)*
- `npm run lint` *(fails: 1 error in order.service.ts)*


------
https://chatgpt.com/codex/tasks/task_e_686d13884724832eacdba6f209d21a99