### PR TITLE
Update order-management deployment

### DIFF
--- a/infrastructure/helm/microservices/order-management/templates/deployment.yaml
+++ b/infrastructure/helm/microservices/order-management/templates/deployment.yaml
@@ -32,33 +32,57 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- $firstKafka := index (splitList "," .Values.kafka.bootstrapServers) 0 }}
+      {{- $kafkaHost := index (splitList ":" $firstKafka) 0 }}
+      {{- $kafkaPort := index (splitList ":" $firstKafka) 1 }}
+      initContainers:
+        - name: wait-for-deps
+          image: busybox:stable
+          command:
+            - sh
+            - -c
+            - |
+              echo "Waiting for Postgres..."
+              until nc -z {{ .Values.database.host }} {{ .Values.database.port }}; do sleep 2; done
+              echo "Waiting for Kafka..."
+              until nc -z {{ $kafkaHost }} {{ $kafkaPort }}; do sleep 2; done
       containers:
         - name: {{ .Chart.Name }}
           {{- with .Values.securityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
-              containerPort: {{ .Values.service.port }}
+              containerPort: 3000
               protocol: TCP
-          {{- with .Values.livenessProbe }}
+          env:
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.database.secretName }}
+                  key: password
+            - name: DATABASE_URL
+              value: postgres://{{ .Values.database.user }}:$(DB_PASSWORD)@{{ .Values.database.host }}:{{ .Values.database.port }}/{{ .Values.database.name }}
+            - name: KAFKA_BOOTSTRAP_SERVERS
+              value: {{ .Values.kafka.bootstrapServers }}
           livenessProbe:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          {{- with .Values.readinessProbe }}
+            httpGet:
+              path: /
+              port: 3000
           readinessProbe:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
+            httpGet:
+              path: /
+              port: 3000
           {{- with .Values.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- with .Values.volumeMounts }}
-          volumeMounts:
-            {{- toYaml . | nindent 12 }}
+            volumeMounts:
+              {{- toYaml . | nindent 12 }}
           {{- end }}
       {{- with .Values.volumes }}
       volumes:


### PR DESCRIPTION
## Summary
- update order-management Helm deployment template
- wait for database and kafka dependencies before starting
- configure main container image and env vars
- add HTTP liveness and readiness probes

## Testing
- `npm test` *(fails: this.orders.findOneOrFail is not a function)*
- `npm run lint` *(fails: NotFoundException is defined but never used)*
- `yamllint infrastructure/helm/microservices/order-management/templates/deployment.yaml` *(fails: too many spaces inside braces)*

------
https://chatgpt.com/codex/tasks/task_e_686f09503c90832ea3ef23997ed382b4