### PR TITLE
Fix Docker build context for order-management service

### DIFF
--- a/Services/Order_Management/order-management/Dockerfile
+++ b/Services/Order_Management/order-management/Dockerfile
@@ -12,4 +12,5 @@ WORKDIR /app
 COPY --from=build /app/dist ./dist
 COPY package.json package-lock.json ./
 RUN npm ci --omit=dev
+RUN ls node_modules | grep kafkajs
 CMD ["node", "dist/main"]

--- a/scripts/build_and_push.sh
+++ b/scripts/build_and_push.sh
@@ -2,7 +2,9 @@
 set -euo pipefail
 
 # ─── CONFIG ────────────────────────────────────────────────────────────────────
-SERVICE_DIR="Services/Order_Management/order-management"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="${SCRIPT_DIR}/.."
+SERVICE_DIR="${PROJECT_ROOT}/Services/Order_Management/order-management"
 IMAGE="ncacademy/express_shipping"
 TAG="latest"
 # ────────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- build Docker image using order-management folder as context
- keep `.dockerignore` entries and add runtime sanity check for kafkajs

## Testing
- `npm run lint`
- `npm test` *(fails: this.items.findOneOrFail is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_687fdee208bc832eb912fefa2a535384